### PR TITLE
Feat: Add support for ignoring CVEs in Bundler Audit Action

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Run Bundle Audit
-      uses: planningcenter/bundle-audit-action@v1
+      uses: planningcenter/bundle-audit-action@v1.1.0
       id: bundle_audit
       with:
         ignore_list: ${{ inputs.ignore_list }}

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: "Bundler Audit Check"
 description: "Runs bundle-audit on pull requests with Gemfile.lock changes and fails the workflow if vulnerabilities are found."
 
 inputs:
-  ignore-list:
+  ignore_list:
     description: "Space-separated list of CVEs to ignore (e.g., CVE-2023-26141 CVE-2021-41182 CVE-2021-41183)"
     required: false
     default: ""
@@ -15,7 +15,7 @@ runs:
       uses: planningcenter/bundle-audit-action@v1
       id: bundle_audit
       with:
-        args: ${{ inputs.ignore-list && '--ignore ' + inputs.ignore-list }}
+        ignore_list: ${{ inputs.ignore_list }}
 
     - name: Fail Workflow if Vulnerabilities Found
       if: ${{ steps.bundle_audit.outputs.has_vulnerabilities == 'true' }}

--- a/action.yml
+++ b/action.yml
@@ -1,12 +1,21 @@
 name: "Bundler Audit Check"
 description: "Runs bundle-audit on pull requests with Gemfile.lock changes and fails the workflow if vulnerabilities are found."
 
+inputs:
+  ignore-list:
+    description: "Space-separated list of CVEs to ignore (e.g., CVE-2023-26141 CVE-2021-41182 CVE-2021-41183)"
+    required: false
+    default: ""
+
+
 runs:
   using: "composite"
   steps:
     - name: Run Bundle Audit
       uses: planningcenter/bundle-audit-action@v1
       id: bundle_audit
+      with:
+        args: ${{ inputs.ignore-list && '--ignore ' + inputs.ignore-list }}
 
     - name: Fail Workflow if Vulnerabilities Found
       if: ${{ steps.bundle_audit.outputs.has_vulnerabilities == 'true' }}


### PR DESCRIPTION
### Why
There are times when we need to ignore certain CVEs when running `bundle-audit`. 

It would be nice if we could pass them into this action like:
```yaml
jobs:
  bundle-audit:
    runs-on: ubuntu-latest
    steps:
      - name: Run PR Bundler Audit Action
        uses: planningcenter/bundle-audit-check-action@v1
        with:
          ignore-list: "CVE-2023-26141 CVE-2021-41182 CVE-2021-41183"
```

### Notes
This introduces an optional `ignore-list` input and then dynamically constructs the `--ignore` flag when passing as `args` to the `bundle-audit-action`.

This change requires the action to run `bundle-audit ${args}`. <-- I don't know how to do this part (or probably don't even have permissions even if I did know 😆 )