### PR TITLE
chore: update `bundle-audit-action` to v1.1.1 to handle empty `ignore_list` inputs

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Run Bundle Audit
-      uses: planningcenter/bundle-audit-action@v1.1.1
+      uses: planningcenter/bundle-audit-action@v1.1
       id: bundle_audit
       with:
         ignore_list: ${{ inputs.ignore_list }}

--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ runs:
   using: "composite"
   steps:
     - name: Run Bundle Audit
-      uses: planningcenter/bundle-audit-action@v1.1.0
+      uses: planningcenter/bundle-audit-action@v1.1.1
       id: bundle_audit
       with:
         ignore_list: ${{ inputs.ignore_list }}


### PR DESCRIPTION
[V1.1.1](https://github.com/planningcenter/bundle-audit-action/pull/2) of `bundle-audit-action` handles the case in which no `ignore_list` value is passed so we should bump to that version.